### PR TITLE
Fix typo in Card Template

### DIFF
--- a/app/views/docs/_how_to_install_into_anki.slim
+++ b/app/views/docs/_how_to_install_into_anki.slim
@@ -105,7 +105,7 @@ p
         &lt;div class=&quot;meaning&quot;&gt;{{meaning}}&lt;/div&gt;
         {{#important_reading}}&lt;div class=&quot;important_reading&quot;&gt;Important Reading: {{important_reading}}&lt;/div&gt;{{/important_reading}}
         {{#onyomi}}&lt;div class=&quot;onyomin&quot;&gt;Onyomi: {{onyomi}}&lt;/div&gt;{{/onyomi}}
-        {{#kunyomi}}&lt;div class=&quot;kunyomi&quot;&gt;Kunyoni: {{kunyomi}}&lt;/div&gt;{{/kunyomi}}
+        {{#kunyomi}}&lt;div class=&quot;kunyomi&quot;&gt;Kunyomi: {{kunyomi}}&lt;/div&gt;{{/kunyomi}}
 
         &lt;div class=&quot;small&quot;&gt;Card type: {{type}}&lt;/div&gt;
 


### PR DESCRIPTION
I noticed that _Kunyomi_ was spelled _Kunyoni_ in the template on the docs page.